### PR TITLE
FIX wrong argument order in Plane fromPoints

### DIFF
--- a/src/main/java/eu/mihosoft/vvecmath/Plane.java
+++ b/src/main/java/eu/mihosoft/vvecmath/Plane.java
@@ -87,17 +87,17 @@ public class Plane {
      * @return a plane
      */
     public static Plane fromPoints(Vector3d a, Vector3d b, Vector3d c) {
-        Vector3d n = b.minus(a).crossed(c.minus(a)).normalized();
+        Vector3d normal = b.minus(a).crossed(c.minus(a)).normalized();
 
-        Vector3d center = Vector3d.zero();
+        Vector3d anchor = Vector3d.zero();
 
-        center = center.plus(a);
-        center = center.plus(b);
-        center = center.plus(c);
+        anchor = anchor.plus(a);
+        anchor = anchor.plus(b);
+        anchor = anchor.plus(c);
 
-        center = center.times(1.0 / 3.0);
+        anchor = anchor.times(1.0 / 3.0);
 
-        return new Plane(n, center);
+        return new Plane(anchor, normal);
     }
 
     /**


### PR DESCRIPTION
In the fromPoints methods, the arguments for anchor and normal where
switched, so every plance constructed this way was wrong. I also changed
the variable names in that function, to make the meaning of the
variables clearer.